### PR TITLE
in thermo_update_temps.php go back to not requiring the time to be passe...

### DIFF
--- a/install/create_tables.sql.IN
+++ b/install/create_tables.sql.IN
@@ -31,10 +31,16 @@ CREATE TABLE IF NOT EXISTS `thermo2__temperatures` (
   `date` datetime NOT NULL,
   `indoor_temp` decimal(5,2) NOT NULL,
   `outdoor_temp` decimal(5,2) DEFAULT NULL,
-  `set_point` decimal(5,2) DEFAULT NULL,
   `indoor_humidity` decimal(5,2) DEFAULT NULL,
   `outdoor_humidity` decimal(5,2) DEFAULT NULL,
   PRIMARY KEY `id_date` (`tstat_uuid`,`date`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS `thermo2__setpoints` (
+  `id` tinyint(3) unsigned NOT NULL,
+  `set_point` decimal(5,2) DEFAULT NULL,
+  `switch_time` datetime NOT NULL,
+  KEY `id` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `thermo2__time_index` (
@@ -92,7 +98,7 @@ INSERT INTO `thermo2__time_index` (`time`) VALUES
 ('23:30:00');
 
 CREATE TABLE IF NOT EXISTS `thermo2__thermostats` (
-  `id` int(2) NOT NULL AUTO_INCREMENT,
+  `id` int(2) unsigned NOT NULL AUTO_INCREMENT,
   `tstat_uuid` varchar(15) NULL,
   `model` varchar(10) NULL,
   `fw_version` varchar(10) NULL,
@@ -104,5 +110,6 @@ CREATE TABLE IF NOT EXISTS `thermo2__thermostats` (
   INDEX `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO `thermo2__thermostats` (`ip`,`name`,`model`) VALUES ('192.168.1.170','Upstairs','CT30');
+INSERT INTO `thermo2__thermostats` (`ip`,`name`,`model`) VALUES ('192.168.1.154','Downstairs','CT30');
+INSERT INTO `thermo2__thermostats` (`ip`,`name`,`model`) VALUES ('192.168.1.155','Upstairs','CT30');
 

--- a/scripts/thermo_update_temps.php
+++ b/scripts/thermo_update_temps.php
@@ -2,19 +2,18 @@
 $start_time = microtime(true);
 require(dirname(__FILE__).'/../common.php');
 
+// set the timezone from the config
+date_default_timezone_set( $timezone );
+
 $log->logInfo( 'temps: Start.' );
 $today = date( 'Y-m-d' );
 $yesterday = date( 'Y-m-d', strtotime( 'yesterday' ));
-if( $argc < 2 )
-{
-	$log->logError( 'temps: required argument missing.  Must send unix timestamp!' );
-	die();
-}
-$unixTime = $argv[1];	// argv[0] is this files name
 
-/**
-	* This script updates the indoor and outdoor temperatures and today's and yesterday total run time for each thermostat.
-	*/
+// Get the local time of the system running this script.  Truncate the minutes and seconds to the nearest multiple of 10 minutes since whatever is being used to run this script every half hour might get delayed a bit (like a cron job)
+$unixTime = substr_replace(date('Y-m-d H:i:s'), "0:00", 15, 4);
+
+// This script updates the indoor and outdoor temperatures and today's and yesterday total run time for each thermostat.
+
 try
 {
 	$sql = "SELECT NOW() as now_time, CONCAT( SUBSTR( NOW() , 1, 15 ) , '0:00' ) as magic_time;";


### PR DESCRIPTION
...d in from a shell script.

This method of getting the time seems to be equivalent and will base the
timezone off of the one in the config.php file

In create_tables.sql.IN modify it to create the initial tables to include
the new setpoint table.  Then no need to run the setpoint update script.
This change also incorporates some other table updates included in the
setpoint update script.

We should probably start calling this "version 3" to avoid confusion of which
table updates need to be done when.
